### PR TITLE
supported-archs: Print all architectures instead of nothing

### DIFF
--- a/tools/supported-archs.tcl
+++ b/tools/supported-archs.tcl
@@ -75,7 +75,8 @@ if {[info exists portinfo(porturl)]} {
     if {[catch {set mport [mportopen $portinfo(porturl) [list subport $portname] {}]}]} {
         ui_warn "failed to open port: $portname"
     } else {
-        puts [_mportkey $mport supported_archs]
+        set archs [_mportkey $mport supported_archs]
+        puts [expr {$archs ne "" ? $archs : "x86_64 i386 ppc64 ppc"}]
     }
     catch {mportclose $mport}
 }


### PR DESCRIPTION
When a port omits `supported_archs`, it is implying that it supports all architectures. In this case, output an explicit list of all architectures instead of an empty string.

I don't know if there is a way to dynamically generate this list instead of hardcoding it.