### PR TITLE
mpbb-checkout: Blacklist mirrors using wildcards

### DIFF
--- a/mpbb-checkout
+++ b/mpbb-checkout
@@ -185,18 +185,12 @@ checkout() {
     # shellcheck disable=SC2154
     (cd "${ports_dir}" && "${option_prefix}/bin/portindex") || return
 
-    local -ar mirrors=(aarnet.au cjj.kr fco.it her.gr jnb.za jog.id kmq.jp
-                       lil.fr mse.uk nou.nc nue.de osl.no pek.cn sea.us
-                       ykf.ca ywg.ca)
-    # Unset IFS to ensure "${mirrors[*]}" uses spaces as separators.
-    (unset IFS && cat > "${option_work_dir}/macports.conf" <<EOF
+    cat > "${option_work_dir}/macports.conf" <<EOF || return
 # Automatically overwritten by mpbb-checkout
 # Do not edit !!!
 sources_conf ${option_work_dir}/sources.conf
-host_blacklist ${mirrors[*]/%/.distfiles.macports.org} \
-               ${mirrors[*]/%/.packages.macports.org}
+host_blacklist *.distfiles.macports.org *.packages.macports.org
 EOF
-) || return
 
     if uname -r | grep -q '^9\.'; then
         # Work around very slow 'xcodebuild -version' on 10.5. Make sure these


### PR DESCRIPTION
Blacklist mirrors using wildcards instead of listing each one. This takes care of the new sha.cn mirror and all other mirrors that might come in the future.

Blacklisting by wildcard is [new in MacPorts 2.5](https://github.com/macports/macports-base/pull/72).

I *think* this change is correct but I haven't tested it.