### PR TITLE
Support for nondistributable archives

### DIFF
--- a/mpbb-checkout
+++ b/mpbb-checkout
@@ -16,6 +16,10 @@ MacPorts to use the latter as a port source.
 
 Options:
 
+  --archive-sites=<URL>
+    Space-separated list of additional URLs to check for preexisting
+    archives. Defaults to \`https://packages-private.macports.org'.
+
   --git[=<path>]
     Use Git to obtain the jobs tools and ports tree; this is the default
     behavior. The path to a Git client may be provided explicitly,
@@ -132,7 +136,7 @@ svn-checkout() {
 
 checkout() {
     local args
-    parseopt git::,jobs-url:,ports-branch:,ports-commit:,ports-url:,svn::,svn-url: "$@" \
+    parseopt archive-sites:,git::,jobs-url:,ports-branch:,ports-commit:,ports-url:,svn::,svn-url: "$@" \
         || return
     # shellcheck disable=SC2086
     set -- ${args+"${args[@]}"}
@@ -145,6 +149,14 @@ checkout() {
 
     # shellcheck disable=SC2154
     local -r ports_dir=${option_work_dir}/ports
+
+    # $option_archive_sites is set by parseopt
+    # shellcheck disable=SC2154
+    : "${option_archive_sites=https://packages-private.macports.org}"
+
+    # $option_archive_sites isn't quoted on purpose
+    # shellcheck disable=SC2086
+    archive_site_local=$(printf '%s/:tbz2 ' ${option_archive_sites})
 
     local checkout git jobs_dir svn
     # shellcheck disable=SC2100 disable=SC2154
@@ -190,6 +202,7 @@ checkout() {
 # Do not edit !!!
 sources_conf ${option_work_dir}/sources.conf
 host_blacklist *.distfiles.macports.org *.packages.macports.org
+archive_site_local ${archive_site_local}
 EOF
 
     if uname -r | grep -q '^9\.'; then

--- a/mpbb-gather-archives
+++ b/mpbb-gather-archives
@@ -17,13 +17,16 @@ directory for uploading.
 Options:
 
   --archive-site=<URL>
-    URL of a mirror to check for preexisting archives. Defaults to
+    URL to check for preexisting public archives. Defaults to
     \`https://packages.macports.org'.
 
+  --archive-site-private=<URL>
+    URL to check for preexisting private archives. Defaults to
+    \`https://packages-private.macports.org'.
+
   --staging-dir=<path>
-    A directory for storing distributable archives before deployment.
-    Defaults to the \`archive-staging' subdirectory of the \`--work-dir'
-    working directory.
+    A directory for storing archives before deployment. Defaults to the
+    \`archive-staging' subdirectory of the \`--work-dir' working directory.
 
 Run \`$prog help' for global options and a list of other subcommands.
 EOF
@@ -31,8 +34,14 @@ EOF
 
 gather-archives() {
     local args
-    parseopt archive-site:,staging-dir: "$@" || return
+    parseopt archive-site:,archive-site-private:,staging-dir: "$@" || return
+    # $option_archive_site is set by parseopt
+    # shellcheck disable=SC2154
     : "${option_archive_site=https://packages.macports.org}"
+    # $option_archive_site_private is set by parseopt
+    # shellcheck disable=SC2154
+    : "${option_archive_site_private=https://packages-private.macports.org}"
+    # $option_staging_dir is set by parseopt
     # shellcheck disable=SC2154
     : "${option_staging_dir=${option_work_dir}/archive-staging}"
     # shellcheck disable=SC2086
@@ -48,23 +57,30 @@ gather-archives() {
         echo
     fi
 
-    mkdir -p "${option_staging_dir}" || return
+    mkdir -p "${option_staging_dir}"/public "${option_staging_dir}"/private || return
 
     status=0
     for archive_path in $("${option_prefix}/bin/port" -q location installed and \( $(cat "${option_work_dir}/all_ports") \)); do
         archive_port=$(basename "$(dirname "${archive_path}")")
         archive_basename=$(basename "${archive_path}")
 
-        if ! curl -fIsL "${option_archive_site}/${archive_port}/${archive_basename}" > /dev/null; then
-            # $option_jobs_dir is set in mpbb
-            # shellcheck disable=SC2154
-            if "${tclsh}" "${option_jobs_dir}/port_binary_distributable.tcl" -v "${archive_port}"; then
-                echo "Staging archive for upload: ${archive_basename}"
-                mkdir -p "${option_staging_dir}/${archive_port}" || { status=$?; break; }
-                ln "${archive_path}" "${option_staging_dir}/${archive_port}/${archive_basename}" || { status=$?; break; }
-            fi
+        # $option_jobs_dir is set in mpbb
+        # shellcheck disable=SC2154
+        if "${tclsh}" "${option_jobs_dir}/port_binary_distributable.tcl" -v "${archive_port}"; then
+            archive_type=public
+            archive_site="${option_archive_site}"
         else
-            echo "Archive was already uploaded: ${archive_basename}"
+            archive_type=private
+            archive_site="${option_archive_site_private}"
+        fi
+        archive_dir="${option_staging_dir}/${archive_type}/${archive_port}"
+
+        if ! curl -fIsL "${archive_site}/${archive_port}/${archive_basename}" > /dev/null; then
+            echo "Staging ${archive_type} archive for upload: ${archive_basename}"
+            mkdir -p "${archive_dir}" || { status=$?; break; }
+            ln "${archive_path}" "${archive_dir}/${archive_basename}" || { status=$?; break; }
+        else
+            echo "Already uploaded ${archive_type} archive: ${archive_basename}"
         fi
     done
 

--- a/mpbb-list-subports
+++ b/mpbb-list-subports
@@ -16,16 +16,21 @@ Print the name and subports of each given port to standard output.
 Options:
 
   --archive-site=<URL>
-    URL of a mirror to check for preexisting archives. Defaults to
+    URL to check for preexisting public archives. Defaults to
     \`https://packages.macports.org'.
+
+  --archive-site-private=<URL>
+    URL to check for preexisting private archives. Defaults to
+    \`https://packages-private.macports.org'.
 
 Run \`$prog help' for global options and a list of other subcommands.
 EOF
 }
 
 print-subports() {
-    local archive_site=$1
-    local portnames=$2
+    local archive_site_public=$1
+    local archive_site_private=$2
+    local portnames=$3
     local port
     local portgroup
     local ports
@@ -44,19 +49,29 @@ print-subports() {
         exclude=0
         exclude_reasons=()
 
-        if [[ -n "${archive_site}" ]]; then
+        if [[ -n "${archive_site_public}" || -n "${archive_site_private}" ]]; then
             # FIXME: this doesn't take selected variants into account
             # $thisdir is set in mpbb
             # shellcheck disable=SC2154
             archive_path=$("${tclsh}" "${thisdir}/tools/archive-path.tcl" "${port}")
             if [[ -f "${archive_path}" ]]; then
                 archive_basename=$(basename "${archive_path}")
-                if curl -fIsL "${archive_site}/${port}/${archive_basename}" > /dev/null; then
+
+                # $option_jobs_dir is set in mpbb
+                # shellcheck disable=SC2154
+                if "${tclsh}" "${option_jobs_dir}/port_binary_distributable.tcl" "${port}"; then
+                    archive_type=public
+                    archive_distributable="distributable"
+                    archive_site="${archive_site_public}"
+                else
+                    archive_type=private
+                    archive_distributable="not distributable"
+                    archive_site="${archive_site_private}"
+                fi
+
+                if [[ -n "${archive_site}" ]] && curl -fIsL "${archive_site}/${port}/${archive_basename}" > /dev/null; then
                     exclude=1
-                    exclude_reasons+=("it has already been built and uploaded")
-                elif ! "${tclsh}" "${option_jobs_dir}/port_binary_distributable.tcl" "${port}"; then
-                    exclude=1
-                    exclude_reasons+=("it has already been built and is not distributable")
+                    exclude_reasons+=("it is ${archive_distributable} and has already been built and uploaded to the ${archive_type} server")
                 fi
             fi
         fi
@@ -112,8 +127,13 @@ list-subports() {
     local log_subports_progress="${option_log_dir}/ports-progress.txt"
 
     local args
-    parseopt archive-site: "$@" || return
+    parseopt archive-site:,archive-site-private: "$@" || return
+    # $option_archive_site is set by parseopt
+    # shellcheck disable=SC2154
     : "${option_archive_site=https://packages.macports.org}"
+    # $option_archive_site_private is set by parseopt
+    # shellcheck disable=SC2154
+    : "${option_archive_site_private=https://packages-private.macports.org}"
     set -- ${args+"${args[@]}"}
 
     if [ $# -le 0 ]; then
@@ -127,7 +147,7 @@ list-subports() {
     mkdir -p "$option_log_dir"
     > "$log_subports_progress"
 
-    print-subports "$option_archive_site" "$*" && success=1
+    print-subports "${option_archive_site}" "${option_archive_site_private}" "$*" && success=1
 
     if [ $success -eq 0 ]; then
         err "None of the specified ports were found in the port index."


### PR DESCRIPTION
This PR enhances mpbb to also handle uploading nondistributable archives to a private server, and to consider the availability of those nondistributable archives when deciding whether to build a port, and making those nondistributable archives available to be installed by MacPorts when using mpbb.

See https://trac.macports.org/ticket/54800.

These modifications are untested.

Any comments about the approach, or anything you'd like to see done differently?