### PR TITLE
Set unrequested flag when installing ports

### DIFF
--- a/mpbb-install-port
+++ b/mpbb-install-port
@@ -60,7 +60,7 @@ install-port() {
     fi
     # $option_prefix is set in mpbb
     # shellcheck disable=SC2154
-    if "${option_prefix}/bin/port" -dkn install "$@"; then
+    if "${option_prefix}/bin/port" -dkn install --unrequested "$@"; then
         # Remove failcache if it exists
         failcache_success "$@"
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
We already install dependencies with the unrequested flag. This now also installs the main port that way. There seems to be no reason to make a distinction between the main port and its dependencies with regard to this flag, since the idea is for all of the ports (or at least, all of the ports that are dependencies of another port) to remain installed, regardless of whether they were originally installed explicitly or as a dependency.

Closes: https://trac.macports.org/ticket/57571