### PR TITLE
Always install the main port from source

### DIFF
--- a/mpbb-install-port
+++ b/mpbb-install-port
@@ -60,7 +60,7 @@ install-port() {
     fi
     # $option_prefix is set in mpbb
     # shellcheck disable=SC2154
-    if "${option_prefix}/bin/port" -dkn install --unrequested "$@"; then
+    if "${option_prefix}/bin/port" -dkns install --unrequested "$@"; then
         # Remove failcache if it exists
         failcache_success "$@"
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
> I would patch `mpbb` instead. We already do some protection to avoid rebuilding existing ports, so there's no need to avoid building from source on the buildbot. We do need to avoid building dependencies from source, but not the main port. – @mojca macports/macports-ports#3353

Any unwanted side effects on the Buildbot?