### PR TITLE
Only selfupdate once every 24 hours

### DIFF
--- a/mpbb-selfupdate
+++ b/mpbb-selfupdate
@@ -51,5 +51,9 @@ selfupdate() {
         rm -rf ${macports_distfile} ${macports_distname} || return
     fi
 
-    "${option_prefix}/bin/port" -d selfupdate --nosync || return
+    # selfupdate at most once every 24 hours
+    if [ ! -f selfupdate.timestamp -o $(($(date +%s) - $(date -r selfupdate.timestamp +%s))) -gt 86400 ]; then
+        "${option_prefix}/bin/port" -d selfupdate --nosync || return
+        touch selfupdate.timestamp
+    fi
 }


### PR DESCRIPTION
Selfupdating takes a fair bit of time, especially when mirroring. Doing it less often should be fine, since Portfiles are not supposed to use new features until 2 weeks after a release.