### PR TITLE
Uninstall ports with no dependents

### DIFF
--- a/mpbb-cleanup
+++ b/mpbb-cleanup
@@ -17,6 +17,24 @@ Run \`$prog help' for global options and a list of other subcommands.
 EOF
 }
 
+format_size() {
+    size="$1"
+    units=KiB
+    if [ "$size" -ge 1024 ]; then
+        size=$(((size + 512) / 1024))
+        units=MiB
+        if [ "$size" -ge 1024 ]; then
+            size=$(((size + 512) / 1024))
+            units=GiB
+        fi
+    fi
+    echo "$size$units"
+}
+
+disk_free() {
+    df -k "$1" | awk 'NR==2 {print $4}'
+}
+
 cleanup() {
     # if this is the very first build, selfupdate did not install port yet
     # $option_prefix is set in mpbb
@@ -26,6 +44,12 @@ cleanup() {
         echo "port not installed at ${option_prefix}/bin/port"
         return
     fi
+
+    # $option_prefix is set in mpbb
+    # shellcheck disable=SC2154
+    disk_free_before=$(disk_free "$option_prefix")
+    echo "----> Free disk space before cleanup: $(format_size "$disk_free_before")"
+    echo
 
     echo "----> Deactivating ports"
     # $option_prefix is set by mpbb
@@ -55,4 +79,10 @@ cleanup() {
         rm -rf "${option_prefix}/var/macports/${dir}"/*
         echo
     done
+
+    # $option_prefix is set in mpbb
+    # shellcheck disable=SC2154
+    disk_free_after=$(disk_free "$option_prefix")
+    echo "----> Free disk space after cleanup: $(format_size "$disk_free_after")"
+    echo "----> Disk space saved by cleanup: $(format_size $((disk_free_after - disk_free_before)))"
   }

--- a/mpbb-cleanup
+++ b/mpbb-cleanup
@@ -58,10 +58,10 @@ cleanup() {
         "${option_prefix}/bin/port" -fp deactivate active
     fi
     echo
-    echo "----> Uninstalling obsolete ports"
+    echo "----> Uninstalling unneeded ports"
     # $thisdir is set by mpbb and points to the directory in which this script resides
     # shellcheck disable=SC2154
-    "${option_prefix}/bin/port-tclsh" "${thisdir}/tools/uninstall-old-ports.tcl"
+    "${option_prefix}/bin/port-tclsh" "${thisdir}/tools/uninstall-unneeded-ports.tcl"
     if [ ! -L "${option_prefix}/var/macports/distfiles" ]; then
         echo
         echo "----> Deleting distfiles"

--- a/tools/uninstall-old-ports.tcl
+++ b/tools/uninstall-old-ports.tcl
@@ -39,6 +39,42 @@ if {$showVersion} {
     exit 0
 }
 
+# Create a lookup table for determining whether a port has dependents
+# (regardless of whether or not those dependents are currently installed)
+foreach source $macports::sources {
+    set source [lindex $source 0]
+    try -pass_signal {
+        set fd [open [macports::getindex $source] r]
+
+        try -pass_signal {
+            while {[gets $fd line] >= 0} {
+                array unset portinfo
+                set name [lindex $line 0]
+                set len  [lindex $line 1]
+                set line [read $fd $len]
+                array set portinfo $line
+
+                # depends_test is not included because mpbb doesn't run `port test'
+                foreach field {depends_build depends_extract depends_fetch depends_lib depends_patch depends_run} {
+                    if [info exists portinfo($field)] {
+                        foreach dependency $portinfo($field) {
+                            set dependency_name [lindex [split $dependency {:}] end]
+                            incr dependents([string tolower $dependency_name])
+                        }
+                    }
+                }
+            }
+        } catch {*} {
+            ui_warn "It looks like your PortIndex file for $source may be corrupt."
+            throw
+        } finally {
+            close $fd
+        }
+    } catch {*} {
+        ui_warn "Can't open index file for source: $source"
+    }
+}
+
 foreach port [registry::entry imaged] {
     # Set to yes if a port should be uninstalled
     set uninstall no
@@ -61,6 +97,15 @@ foreach port [registry::entry imaged] {
             # The version in the index is different than the installed one
             ui_msg "Removing ${installed_name} @${installed_version}_${installed_revision}${installed_variants} because there is a newer version in the PortIndex"
             set uninstall yes
+        } else {
+            set lowercase_name [string tolower $installed_name]
+            if {![info exists dependents($lowercase_name)]} {
+                # Nothing depends on it
+                ui_msg "Removing ${installed_name} @${installed_version}_${installed_revision}${installed_variants} because no port in the PortIndex depends on it"
+                set uninstall yes
+            } elseif {no} {
+                ui_msg "Not removing ${installed_name} @${installed_version}_${installed_revision}${installed_variants} because it has $dependents($lowercase_name) dependents"
+            }
         }
     }
     if {$uninstall} {

--- a/tools/uninstall-old-ports.tcl
+++ b/tools/uninstall-old-ports.tcl
@@ -40,8 +40,8 @@ if {$showVersion} {
 }
 
 foreach port [registry::entry imaged] {
-    # Set to yes if a port is not current
-    set old no
+    # Set to yes if a port should be uninstalled
+    set uninstall no
 
     set installed_name [$port name]
     set installed_version [$port version]
@@ -50,21 +50,20 @@ foreach port [registry::entry imaged] {
 
     set portindex_match [mportlookup $installed_name]
     if {[llength $portindex_match] < 2} {
-        # Not found in index, classify as old
+        # Not found in index
         ui_msg "Removing ${installed_name} @${installed_version}_${installed_revision}${installed_variants} because it is no longer in the PortIndex"
-        set old yes
+        set uninstall yes
     } else {
         array unset portinfo
         array set portinfo [lindex $portindex_match 1]
 
         if {$portinfo(version) ne $installed_version || $portinfo(revision) != $installed_revision} {
-            # Port is not current because the version in the index is
-            # different than the installed one
+            # The version in the index is different than the installed one
             ui_msg "Removing ${installed_name} @${installed_version}_${installed_revision}${installed_variants} because there is a newer version in the PortIndex"
-            set old yes
+            set uninstall yes
         }
     }
-    if {$old} {
+    if {$uninstall} {
         registry_uninstall::uninstall $installed_name $installed_version $installed_revision $installed_variants [list ports_force 1]
     }
 }

--- a/tools/uninstall-unneeded-ports.tcl
+++ b/tools/uninstall-unneeded-ports.tcl
@@ -34,7 +34,7 @@ package require macports
 mportinit
 
 if {$showVersion} {
-    puts "uninstall-old-ports.tcl version $MY_VERSION"
+    puts "uninstall-unneeded-ports.tcl version $MY_VERSION"
     puts "MacPorts version [macports::version]"
     exit 0
 }


### PR DESCRIPTION
This PR implements one proposal from https://trac.macports.org/ticket/57464: uninstalling ports that have no dependents. I believe it works correctly but I have only tested it by running uninstall-old-ports.tcl directly, not using mpbb.

I had originally envisioned only checking the ports that were modified by the commit, but the existing uninstall-old-ports.tcl script already checks all ports, and this seemed like a convenient place to implement it. Checking all ports is ideal because it ensure that if port X is modified to remove a dependency on port Y, and no other port depends on Y, then Y will be uninstalled even if Y was not modified by the commit. It also means I won't have to manually uninstall leaves on each builder once after merging this PR.

My first commit renames the variable `old` to `uninstall`, since the script is now uninstalling for reasons other than a port being old. ~We might also want to rename the script but I haven't done that yet.~

~The second commit is my original attempt, which used `mportsearch` to find each port's dependents. This proved to be too slow; on my MacBook Pro it took about 0.4 seconds to find out if a single port had any dependents, and since I expect we will have around 8000 ports with dependents, that would add over 50 minutes to each build. `mportsearch` reads the PortIndex each time it's called; it would be better to keep it in memory. And it also returns all results; we only need to know whether there is any dependent, not a whole list of them.~

The third commit is a better implementation which first reads the PortIndex once and creates a lookup table from it so we can easily tell whether a port has dependents. Checking almost 3000 installed ports on my MacBook Pro takes only a couple seconds.

~I can squash the 2nd and 3rd commits before merging and add a reference to the ticket URL.~

Update 20190606: The old second commit with the slow `mportsearch` implementation of finding ports with no dependents is removed. The new second commit shows free disk space before and after cleanup and shows how much space cleanup saved. The new fourth commit renames the script from uninstall-old-ports.tcl to uninstall-unneeded-ports.tcl.