### PR TITLE
Allow deleting distfiles if distfiles is a symlink

### DIFF
--- a/mpbb-cleanup
+++ b/mpbb-cleanup
@@ -86,11 +86,11 @@ cleanup() {
         # $thisdir is set by mpbb and points to the directory in which this script resides
         # shellcheck disable=SC2154
         "$(readlink "${option_prefix}/bin/port-tclsh")" "${thisdir}/tools/uninstall-unneeded-ports.tcl"
-        if [ ! -L "${option_prefix}/var/macports/distfiles" ]; then
+        if [ ! -e "${option_prefix}/var/macports/distfiles/ports.tar.gz" ]; then
             echo
             echo "----> Deleting distfiles"
-            find "${option_prefix}/var/macports/distfiles" -type f \! -newerat "4 hours ago" -print -delete | sed -E 's/^/Deleting distfile /'
-            find "${option_prefix}/var/macports/distfiles" -type d -mindepth 1 -empty -print -delete | sed -E 's/^/Deleting directory /'
+            find "${option_prefix}/var/macports/distfiles/" -type f \! -newerat "4 hours ago" -print -delete | sed -E 's/^/Deleting distfile /'
+            find "${option_prefix}/var/macports/distfiles/" -type d -mindepth 1 -empty -print -delete | sed -E 's/^/Deleting directory /'
         fi
         # clean out failcache at most once every week
         timestamp="${option_work_dir}/failcache-cleanup.timestamp"


### PR DESCRIPTION
When I originally prevented deletions if distfiles was a symlink in f151333 I was considering replacing the distfiles directory on each worker with a symlink to the master distfiles volume mounted over AFP/SMB to save disk space on the workers. I didn't end up trying that, but on the Apple Silicon workers I have now made distfiles a symlink to a shared directory where I do want deletions to occur, so I've changed the condition so now deletions can occur unless ports.tar.gz exists; that would only exist on the master. I added a slash to the end of the distfiles path since otherwise find won't descend into the symlinks.